### PR TITLE
Fix msvc build

### DIFF
--- a/custom/arch/cc_windows.h
+++ b/custom/arch/cc_windows.h
@@ -79,7 +79,9 @@ typedef int sys_prot_t;
 
 #ifdef _MSC_VER
 /* C runtime functions redefined */
+#if _MSC_VER < 1900
 #define snprintf _snprintf
+#endif
 #define strdup   _strdup
 #endif
 

--- a/custom/sys_arch.c
+++ b/custom/sys_arch.c
@@ -42,34 +42,22 @@
   #define SYS_INITIALIZED() (freq.QuadPart != 0)
   
   static DWORD netconn_sem_tls_index;
-  
-  static HCRYPTPROV hcrypt;
-  
+
   u32_t
   sys_win_rand(void)
   {
     u32_t ret;
-    if (CryptGenRandom(hcrypt, sizeof(ret), (BYTE*)&ret)) {
-      return ret;
+    if (SUCCEEDED(BCryptGenRandom(NULL, (PUCHAR)&ret, sizeof(ret), BCRYPT_USE_SYSTEM_PREFERRED_RNG))) {
+        return ret;
     }
-    LWIP_ASSERT("CryptGenRandom failed", 0);
+    LWIP_ASSERT("BCryptGenRandom failed", 0);
     return 0;
   }
   
   static void
   sys_win_rand_init(void)
   {
-    if (!CryptAcquireContext(&hcrypt, NULL, NULL, PROV_RSA_FULL, 0)) {
-      DWORD err = GetLastError();
-      LWIP_PLATFORM_DIAG(("CryptAcquireContext failed with error %d, trying to create NEWKEYSET", (int)err));
-      if(!CryptAcquireContext(&hcrypt, NULL, NULL, PROV_RSA_FULL, CRYPT_NEWKEYSET)) {
-        char errbuf[128];
-        err = GetLastError();
-        snprintf(errbuf, sizeof(errbuf), "CryptAcquireContext failed with error %d", (int)err);
-        LWIP_UNUSED_ARG(err);
-        LWIP_ASSERT(errbuf, 0);
-      }
-    }
+    // BCryptGenRandom does not require any setup
   }
   
   static void


### PR DESCRIPTION
- Redefinition of `snprintf` gives a compiler error on msvc
- `BCryptGenRandom` is more portable than `CryptGenRandom`